### PR TITLE
create tags in -codified and -html repos after build (#5)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,6 +43,8 @@ build_script:
 test_script:
   - echo Skipping doomed test discovery to save time
 
+skip_tags: true   # don't create builds for tags (only for branches)
+
 deploy_script:
   - cd ..\dc-law-xml-codified
   - "%PYTHON%\\python.exe ..\\dc-law-tools\\appveyor-deploy\\dc-law-xml-codified.py"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,5 +47,5 @@ skip_tags: true   # don't create builds for tags (only for branches)
 
 deploy_script:
   - cd ..\dc-law-xml-codified
-  - "%PYTHON%\\python.exe ..\\dc-law-tools\\appveyor-deploy\\dc-law-xml-codified.py"
+  - "%PYTHON%\\python.exe -u ..\\dc-law-tools\\appveyor-deploy\\dc-law-xml-codified.py"
 


### PR DESCRIPTION
See details here: https://github.com/openlawlibrary/OpenLawPlatform/issues/5

*Note that this PR excludes the "test building" commit, and the "deploy codified XML from dc-law-xml build 1.0.499" commit, from the example above.*

Summary:
- do not trigger builds on tags (only on branches)
- show deploy messages unbuffered (better user experience when watching the AppVeyor builds)